### PR TITLE
Master is worker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,22 @@
 project(ThreadPool)
 cmake_minimum_required(VERSION 3.1)
 
-set(CMAKE_CXX_STANDARD 11)
-
 include_directories(include)
-add_definitions(-Wall -Wextra -pedantic)
+
+set(WARNING_FLAGS -Wall -Wextra -pedantic)
+
+if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+endif()
 
 add_library(ThreadPool SHARED src/ThreadPool.cc)
+target_compile_options(ThreadPool PUBLIC ${WARNING_FLAGS})
+set_target_properties(ThreadPool PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED True)
+
 install(TARGETS ThreadPool LIBRARY DESTINATION lib)
 install(FILES include/ThreadPool.hh DESTINATION include)
 
 add_executable(test_ThreadPool test/test_ParallelMap.cc test/catch_main.cc)
 target_link_libraries(test_ThreadPool ThreadPool)
+target_compile_options(test_ThreadPool PUBLIC ${WARNING_FLAGS})
+set_target_properties(test_ThreadPool PROPERTIES CXX_STANDARD 14 CXX_STANDARD_REQUIRED True)

--- a/example.cc
+++ b/example.cc
@@ -9,46 +9,46 @@ using namespace std;
 
 
 void scale(int i, double* a, double* b) {
-        a[i]=4*b[i];
+  a[i]=4*b[i];
 }
 
 int main () {
 
-        ThreadPool pool(8);
+  ThreadPool pool(8);
 
-        int N = 1e9;
-        auto a = (double*)calloc(N,sizeof(double));
-        auto b = (double*)calloc(N,sizeof(double));
-        for (int i=0; i<N; i++) { b[i] = i; }
+  int N = 1e9;
+  auto a = (double*)calloc(N,sizeof(double));
+  auto b = (double*)calloc(N,sizeof(double));
+  for (int i=0; i<N; i++) { b[i] = i; } // initialize
 
 
-        // cold start for timing purposes
-        pool.ParallelFor(0,N,scale,a,b);
+  // cold start for timing purposes
+  pool.ParallelFor(0,N,scale,a,b);
 
-        int ntrials = 10;
-        double tperformance = 0.0;
-        cout << "Callable: c-function pointer\n";
-        for (int i=0; i<ntrials; i++)
-        {
-                Timer timer([&](int elapsed){
-                                cout << "Trial " << i << ": "<< elapsed*1e-6 << " ms\n";
-                                tperformance+=elapsed;
-                        });
-                pool.ParallelFor(0,N,scale,a,b);
-        }
-        cout << "Average: " << tperformance*1e-6 / ntrials << " ms\n\n";
+  int ntrials = 10;
+  double tperformance = 0.0;
+  cout << "Callable: c-function pointer\n";
+  for (int i=0; i<ntrials; i++)
+  {
+    Timer timer([&](int elapsed){
+        cout << "Trial " << i << ": "<< elapsed*1e-6 << " ms\n";
+        tperformance+=elapsed;
+      });
+    pool.ParallelFor(0,N,scale,a,b);
+  }
+  cout << "Average: " << tperformance*1e-6 / ntrials << " ms\n\n";
 
-        tperformance = 0.0;
-        cout << "Callable: lambda function (without capture) \n";
-        for (int i=0; i<ntrials; i++)
-        {
-                Timer timer([&](int elapsed){
-                                cout << "Trial " << i << ": "<< elapsed*1e-6 << " ms\n";
-                                tperformance+=elapsed;
-                        });
-                pool.ParallelFor(0,N,[](int k, double* a, double* b) {return a[k] = 4*b[k];},a,b);
-        }
-        cout << "Average: " << tperformance*1e-6 / ntrials << " ms\n\n";
+  tperformance = 0.0;
+  cout << "Callable: lambda function (without capture) \n";
+  for (int i=0; i<ntrials; i++)
+  {
+    Timer timer([&](int elapsed){
+        cout << "Trial " << i << ": "<< elapsed*1e-6 << " ms\n";
+        tperformance+=elapsed;
+      });
+    pool.ParallelFor(0,N,[](int k, double* a, double* b) {return a[k] = 4*b[k];},a,b);
+  }
+  cout << "Average: " << tperformance*1e-6 / ntrials << " ms\n\n";
 
-        return 0;
+  return 0;
 }

--- a/include/ThreadPool.hh
+++ b/include/ThreadPool.hh
@@ -41,6 +41,7 @@ public:
                                         m_promises[mypromise].set_value();
                                 });
                 }
+                m_taskQueue.pop()(); // master thread is also a worker
                 Finish();
         }
         template<typename InputIt, typename T>
@@ -57,9 +58,10 @@ public:
                     while (threadBegin != threadEnd) {
                         *(threadOutput++) = func(*(threadBegin++));
                     }
-                    m_promises[mypromise].set_value();
+                    m_promises[mypromise].set_value(); // master thread is also a worker
                 });
             }
+            m_taskQueue.pop()();
             Finish();
         }
 

--- a/src/ThreadPool.cc
+++ b/src/ThreadPool.cc
@@ -1,14 +1,14 @@
 #include "ThreadPool.hh"
 
 ThreadPool::ThreadPool(uint32_t numthreads) : m_nthreads(numthreads), m_stopWorkers(false) {
-        for (uint32_t i=0; i<numthreads;i++) {
-                m_workers.emplace_back(&ThreadPool::Worker, this);
-        }
+    for (uint32_t i=0; i<numthreads-1;i++) { // -1 b/c main thread is also a worker
+        m_workers.emplace_back(&ThreadPool::Worker, this);
+    }
 }
 ThreadPool::~ThreadPool() {
-        m_stopWorkers = true;
-        m_taskQueue.join();
-        JoinAll();
+    m_stopWorkers = true;
+    m_taskQueue.join();
+    JoinAll();
 }
 
 void ThreadPool::Worker() {
@@ -25,7 +25,7 @@ void ThreadPool::Worker() {
     }
 }
 void ThreadPool::JoinAll() {
-        for (auto& worker : m_workers) { worker.join(); }
+    for (auto& worker : m_workers) { worker.join(); }
 }
 void ThreadPool::Finish() {
     for (auto& promise : m_promises) promise.get_future().get();


### PR DESCRIPTION
Main changes are in ThreadPool.hh/cc. Simply put, instead of just having the main thread (which called ParallelFor) wait, it pops one of the tasks of the queue and executes it. Thus the number of std::thread workers is NUM_THREADS-1, so that there are a total of NUM_THREADS (including the master) running at any one time. 

@jbradt Did this as a pull request just so you would be aware. I will merge it in.
